### PR TITLE
Harden supply-chain workflows and governance docs

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,28 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '23 14 * * 4'
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze (python)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
+        with:
+          languages: python
+          build-mode: none
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,16 @@
+name: Dependency Review
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    name: Dependency review
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dependency review
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0

--- a/.github/workflows/docs-validation.yml
+++ b/.github/workflows/docs-validation.yml
@@ -1,5 +1,8 @@
 name: Docs validation
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main ]

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,32 @@
+name: Scorecard supply-chain security
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: '17 14 * * 1'
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Run analysis
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+      - name: Upload results to code scanning
+        uses: github/codeql-action/upload-sarif@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
+        with:
+          sarif_file: results.sarif

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -6,13 +6,15 @@ on:
   schedule:
     - cron: '17 14 * * 1'
 
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   analysis:
     name: Scorecard analysis
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       security-events: write
       id-token: write
     steps:


### PR DESCRIPTION
## Summary

- Scoped the existing documentation-validation workflow `GITHUB_TOKEN` to `contents: read`.
- Added SHA-pinned pull-request dependency review for dependency changes.
- Added a scheduled OpenSSF Scorecard workflow that publishes SARIF results to code scanning.
- Added SHA-pinned CodeQL advanced setup for the repository's Python scripts.

> **No repository settings were changed by this PR automation.** Rulesets, branch protection, secret scanning, Actions defaults, and organization policies require administrator action; the specific follow-ups are below.

## OpenSSF Scorecard analysis and calls to action

- Prior Scorecard evidence/overall score: **unavailable**; the approved proposal and validation report did not include a Scorecard run or score.
- Expected file-based improvements after the new workflow runs:
  - Token-Permissions: the existing documentation workflow now has an explicit read-only token scope.
  - Pinned-Dependencies: all newly referenced Actions are pinned to verified full commit SHAs with version comments.
  - SAST: CodeQL now analyzes Python scripts on pushes, pull requests, and a weekly schedule.
  - Dependency review: pull requests now receive dependency-change analysis.
- Manual follow-up checks that cannot be fully fixed by repository files: Branch-Protection, Code-Review, Signed-Releases, Vulnerabilities, secret scanning/push protection, and organization agent governance.
- Call to action: after this workflow runs, review its Scorecard check table in **Security -> Supply-chain security -> Scorecard** and use the checklist below to address remaining controls.

## Validation

- [x] `git diff --check`
- [x] Parsed all four workflow YAML files and confirmed every `uses:` reference is a full 40-character SHA.
- [x] Verified new pins against upstream tags: dependency-review-action v5.0.0, scorecard-action v2.4.3, CodeQL v4.37.1; preserved checkout v7.0.0 pin was also verified.
- [x] Shell syntax and Python AST parsing passed.
- [x] `npm ci`, `npm run spell`, and `hugo build -d public` passed.
- [x] Token/secret pattern leak scan of the staged diff passed.
- [x] Signed commit verified locally and by GitHub (`valid`).
- [x] `actionlint` was unavailable locally.
- [x] `npm run lint:md` failed because its existing script invokes unavailable `markdownlint-cli`; this PR does not modify that script or Markdown files.
- [x] `npm run lint:mermaid` failed on the existing Mermaid diagram at `content/develop/world-contracts/world.move.md:33`; this PR does not modify that content.
- [x] Scorecard was not re-run locally: no prior Scorecard baseline was supplied and no local Scorecard binary was available.

## Manual follow-up required

The PR only changes repository files. A repository, organization, or enterprise administrator still needs to complete these settings tasks:

- [x] Merge this draft after review and passing checks.
- [x] In **Settings -> Rules -> Rulesets**, review the active `mainline` default-branch ruleset. Preserve its deletion/non-fast-forward/signed-commit restrictions, set at least one required approving review, and ensure direct pushes and bypass actors are appropriately restricted.
  - The validated public ruleset has zero required approving reviews, no required status checks, and no CODEOWNERS mappings. Do not require CODEOWNERS until maintainers supply valid owner identities and merge a separately reviewed mapping.
- [x] After the new workflows have run once, add the exact observed job names as required checks where compatible with the existing ruleset: `Validate documentation (Hugo, linters, spellcheck, linkcheck)`, `Analyze (python)`, and `Dependency review`. Consider `Scorecard analysis` advisory unless the maintainers choose to make it blocking.
  - Verify with an exported ruleset summary or screenshot and a test PR that cannot merge while a required check fails.
- [x] In **Settings -> Code security and analysis**, enable or verify dependency graph, Dependabot alerts, Dependabot security updates, malware detection (where supported), secret scanning, push protection, and validity checks.
  - Confirm code-scanning alerts are routed to a named maintainer/team and record the triage owner.
  - Verify with screenshots or exported settings and confirmation that push protection blocks a test secret pattern according to organization policy.
- [x] Review the existing `.github/dependabot.yml` against current repository manifests. It was intentionally not changed by this PR because the approved validation classified existing Dependabot automation as a compensating control rather than an actionable change. If updating it separately, retain only detected Go, npm, Docker, GitHub Actions, and devcontainer ecosystems and use weekly scheduling, `open-pull-requests-limit: 10`, grouped minor/patch updates, and a five-day cooldown.
- [x] Define valid GitHub users/teams before adding CODEOWNERS; then cover workflows, dependency manifests/lockfiles, release scripts, infrastructure, and security documentation. Verify GitHub recognizes the file and a protected-path test PR requests the expected reviewers.
- [x] Document AI/agent guardrails: human review for generated changes, no agent direct pushes to protected branches, least-privilege/revocable tokens, dependency review for generated dependency changes, and no privileged execution of untrusted code. Retain policy-link and token-scope evidence.
- [x] This repository currently has no release/package/deploy artifact to attest. If publishing is introduced, restrict release/tag creation, require checksums/signatures/SBOMs and GitHub/Sigstore provenance, use protected environments as appropriate, and enable release immutability. Retain a release link and provenance/SBOM/signature verification output.

Suggested verification evidence: ruleset screenshot/export; configured required-check names; secret-scanning and push-protection confirmation; code-scanning triage owner; Dependabot configuration review; CODEOWNERS test-PR result after owner identities are supplied; agent-policy link; and release provenance/SBOM/signature evidence if releases are introduced.

No repository settings were changed by this PR automation.

## References

- Approved proposal: `/home/scetrov/.agents/skills/github-supply-chain-hardening-analysis/proposals/Scetrov_frontier.scetrov.live.json`
- Current-state validation: `/home/scetrov/source/security-hardening/remediation-validation/frontier.scetrov.live.md`
