### PR TITLE
fix(security): harden repository supply chain

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # Use the same base image that was previously specified in devcontainer.json
-FROM mcr.microsoft.com/devcontainers/go:2.1-trixie
+FROM mcr.microsoft.com/devcontainers/go:2.1-trixie@sha256:8a3898b2f993dbf1fa2aa98f7be8d2b8f36a114bf35bc3525800f7c99f3a3480
 
 # Install Node.js 24 (LTS) via NodeSource (use GPG-signed repo instead of piping)
 RUN apt-get update && apt-get install -y curl ca-certificates gnupg && \
@@ -9,8 +9,8 @@ RUN apt-get update && apt-get install -y curl ca-certificates gnupg && \
     rm /tmp/nodesource.gpg.key && \
     echo "deb [signed-by=/usr/share/keyrings/nodesource.gpg] https://deb.nodesource.com/node_24.x nodistro main" > /etc/apt/sources.list.d/nodesource.list && \
     apt-get update && apt-get install -y nodejs && \
-    npm install -g npm@latest && \
-    npm install -g markdownlint-cli
+    npm install -g npm@12.0.1 && \
+    npm install -g markdownlint-cli@0.49.1
 
 # Instll prerequisites for pre-commit hooks
 RUN apt-get update && apt-get install -y libnss3 libatk1.0-0 libatk-bridge2.0-0 libcups2 libx11-xcb1 \
@@ -18,9 +18,8 @@ RUN apt-get update && apt-get install -y libnss3 libatk1.0-0 libatk-bridge2.0-0 
     pre-commit
 
 # Install htmltest (link checker) so pre-commit hooks can run inside the devcontainer
-# Use the Go toolchain to install the latest htmltest binary reliably
 RUN apt-get update && apt-get install -y ca-certificates curl && \
-        GOBIN=/usr/local/bin /usr/local/go/bin/go install github.com/wjdp/htmltest@latest && \
+        GOBIN=/usr/local/bin /usr/local/go/bin/go install github.com/wjdp/htmltest@v0.17.0 && \
         if [ ! -x /usr/local/bin/htmltest ]; then \
             echo "htmltest install failed" >&2; exit 1; \
         fi

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -10,12 +10,14 @@ on:
 
 permissions:
   contents: read
-  security-events: write
 
 jobs:
   analyze:
     name: Analyze (python)
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/docs-validation.yml
+++ b/.github/workflows/docs-validation.yml
@@ -26,12 +26,7 @@ jobs:
           cache: 'npm'
 
       - name: Install devDependencies (markdownlint-cli, cspell)
-        run: |
-          if [ -f package-lock.json ]; then
-            npm ci
-          else
-            npm install
-          fi
+        run: npm ci
 
       - name: Node & npm versions (debug)
         run: |
@@ -48,13 +43,13 @@ jobs:
         run: hugo build -d public
 
       - name: Run markdownlint
-        run: npx markdownlint-cli "content/**/*.md" ".github/**/*.md"
+        run: npm run lint:md
 
       - name: Validate TOML frontmatter
         run: ./.githooks/validate-frontmatter.sh
 
       - name: Run cspell (spellcheck)
-        run: npx cspell "content/**/*.md"
+        run: npm run spell
 
       - name: Set up Go (for htmltest)
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
@@ -63,8 +58,7 @@ jobs:
 
       - name: Install htmltest
         run: |
-          # install htmltest from the module (cmd path changed in upstream releases)
-          go install github.com/wjdp/htmltest@latest
+          go install github.com/wjdp/htmltest@v0.17.0
           echo "$HOME/go/bin" >> $GITHUB_PATH
 
       - name: Run htmltest (full-site link/HTML checks)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,15 @@
+# Security Policy
+
+## Supported scope
+
+This policy covers the source repository, its GitHub Actions workflows, development-container configuration, and the published site configuration. The static site does not provide user accounts or a public application API.
+
+## Reporting a vulnerability
+
+Please use [GitHub private vulnerability reporting](https://github.com/Scetrov/frontier.scetrov.live/security/advisories/new) for this repository. Include a clear description, reproduction steps or proof of concept, affected files or workflows, and the potential impact.
+
+Do not open a public issue, publish a proof of concept, or otherwise disclose the vulnerability publicly before we have agreed on a coordinated disclosure plan.
+
+## Response process
+
+We aim to acknowledge reports within **7 calendar days**. We will assess the report, communicate the expected remediation timeline, and coordinate disclosure with the reporter before publishing details. Please allow reasonable time for a fix or mitigation to be released before public disclosure.

--- a/content/develop/world-contracts/world.move.md
+++ b/content/develop/world-contracts/world.move.md
@@ -32,13 +32,13 @@ The `GovernorCap` is the top-level authority in the EVE Frontier access control 
 ```mermaid
 sequenceDiagram
     participant Deployer
-    participant init()
+    participant Init as init()
     participant Sui Runtime
 
-    Deployer->>init(): Package published
-    init()->>Sui Runtime: object::new(ctx) → UID
-    init()->>Sui Runtime: Create GovernorCap{id, governor: sender}
-    init()->>Sui Runtime: transfer::transfer(gov_cap, sender)
+    Deployer->>Init: Package published
+    Init->>Sui Runtime: object::new(ctx) → UID
+    Init->>Sui Runtime: Create GovernorCap{id, governor: sender}
+    Init->>Sui Runtime: transfer::transfer(gov_cap, sender)
     Note over Deployer: GovernorCap now owned by deployer
 ```
 

--- a/docs/scorecard-triage.md
+++ b/docs/scorecard-triage.md
@@ -1,0 +1,23 @@
+# OpenSSF Scorecard triage
+
+This record distinguishes Scorecard findings that require remediation from intentional exceptions suited to this repository's current scope and maintainer model. It supplements, but does not replace, GitHub's recorded alert dismissals.
+
+## Implemented controls
+
+- The `main` ruleset blocks deletion and force pushes, applies to administrators, requires a pull request, and requires the documented validation checks to pass.
+- GitHub private vulnerability reporting is enabled; see [`SECURITY.md`](../SECURITY.md).
+- CodeQL grants `security-events: write` only to its analysis job.
+- Development-container and documentation-validation executable inputs are pinned, and the Node lockfile resolves patched development dependencies.
+
+## Intentional exceptions
+
+| Scorecard area | Rationale | Reconsideration trigger |
+| --- | --- | --- |
+| Code review | The repository has one trusted maintainer with merge access. Requiring an approving peer review would make normal maintenance impossible without creating a nominal reviewer. Automated validation remains required. | Require an approving peer review when a second trusted maintainer receives merge access, or when governance changes to provide an independent reviewer. |
+| Fuzzing | This is a static Hugo documentation site; it does not contain a parser, network service, or other untrusted-input application component for which new fuzzing infrastructure would be proportionate. | Reassess if the repository adds untrusted-input processing, service code, or a custom parser. |
+| OpenSSF Best Practices badge | Earning and maintaining the external badge is not a project goal. Concrete security controls are tracked and improved independently of badge status. | Reassess if users, contributors, or the project governance model require external certification. |
+| SAST coverage of historical commits | CodeQL analyzes the current tree on pushes and pull requests. Retrospective scanning of every historical commit would not improve protection for the deployed static site proportionately. | Reassess after a security incident, a significant codebase expansion, or a governance requirement for historical analysis. |
+
+## Branch ruleset verification
+
+The effective GitHub ruleset for `main` is verified after configuration through the GitHub API. Required status checks: `Dependency review`, `Analyze (python)`, and `Validate documentation (Hugo, linters, spellcheck, linkcheck)`. No approving peer review is required while the sole-maintainer exception applies.

--- a/openspec/changes/harden-repository-supply-chain/.openspec.yaml
+++ b/openspec/changes/harden-repository-supply-chain/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-19

--- a/openspec/changes/harden-repository-supply-chain/design.md
+++ b/openspec/changes/harden-repository-supply-chain/design.md
@@ -1,0 +1,77 @@
+## Context
+
+The repository is a public, predominantly static Hugo documentation site maintained by one primary owner. Its current security controls include Dependabot, dependency review, CodeQL on push and pull request, secret scanning with push protection, and a weekly Scorecard workflow. The Scorecard results identify mutable tool installation inputs, an unprotected `main` branch, a missing security disclosure policy, broad placement of CodeQL upload permission, and a vulnerable transitive development dependency.
+
+The repository does not run an application service or expose a public API. Its development tooling executes in contributor workstations and GitHub Actions, so supply-chain reproducibility and the integrity of automation are the principal concerns.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Prevent destructive or unvalidated changes to `main` while keeping the repository workable for its sole maintainer.
+- Ensure each CI and development-container tool is selected from a deterministic version or immutable image digest.
+- Keep privileged GitHub token access limited to the CodeQL upload job.
+- Provide a clear, private vulnerability-reporting route.
+- Remove the known vulnerable `basic-ftp` resolution from the development dependency graph.
+- Preserve an auditable rationale for intentionally unaddressed Scorecard criteria.
+
+**Non-Goals:**
+- Achieving a perfect Scorecard score or earning an OpenSSF Best Practices badge.
+- Requiring an independent approving review before every merge while there is only one trusted maintainer.
+- Adding fuzzing infrastructure to static-site tooling.
+- Changing public website functionality, content, or API behavior.
+- Backfilling static analysis for historical commits when the current tree is analyzed on every push and pull request.
+
+## Decisions
+
+### Use a protected-branch ruleset with required checks, but no required peer approval
+
+`main` will disallow deletion and force pushes, require pull requests and the existing successful validation checks, and apply the rules to administrators. Required checks protect deployed content and automation inputs without needing a second account. The ruleset will not require an approving review while the repository has a sole trusted maintainer.
+
+**Alternative considered:** Require one approving review to satisfy Scorecard's code-review check completely. This would block the only maintainer from merging ordinary work and invites a nominal rather than independent review.
+
+### Scope CodeQL upload permission to the analysis job
+
+`security-events: write` is required to upload CodeQL SARIF results. It will be declared only in the CodeQL analysis job; all other workflow and default permissions remain read-only.
+
+**Alternative considered:** Remove the permission. This would prevent CodeQL from publishing findings and is therefore not acceptable.
+
+### Pin executable build inputs at their selection point
+
+The devcontainer base image will use a tag plus immutable digest. Global npm packages and `go install` modules will use explicit versions. Documentation validation will use project `npm run` commands after `npm ci`, keeping execution tied to the committed lockfile.
+
+**Alternative considered:** Keep `latest` values and rely on Dependabot. Dependabot updates declared dependencies but cannot make a mutable build reproduce exactly or prevent a changed upstream artifact from executing during the next build.
+
+### Resolve `basic-ftp` through the lockfile with a compatible patched version
+
+The `basic-ftp` transitive resolution will be raised to at least 5.3.1, using the package manager's supported override mechanism if the immediate parent does not update first. The lockfile will be regenerated and verified. This addresses both known denial-of-service advisories while retaining the existing Mermaid CLI tooling.
+
+**Alternative considered:** Dismiss because the dependency is development-only and no repository code invokes FTP. The exposure is low, but a known patched resolution is available and developer/CI tooling still executes the dependency graph.
+
+### Record intentional Scorecard exceptions in repository documentation
+
+A concise triage record will explain why peer-review enforcement, fuzzing, the external certification badge, and historical-commit SAST coverage are not adopted. It will name the condition that triggers reconsideration: adding another maintainer, introducing untrusted-input service code, or changing the project governance model.
+
+**Alternative considered:** Dismiss findings only in GitHub's UI. That rationale is not version-controlled, discoverable to contributors, or reviewable alongside governance changes.
+
+## Risks / Trade-offs
+
+- [Pinned versions can age or acquire vulnerabilities] → Continue Dependabot updates and periodically refresh pins through reviewed changes.
+- [Branch requirements can slow urgent corrections] → Retain the owner's administrator access while enforcing rules; document an emergency exception process in the security policy/ruleset administration.
+- [A sole maintainer lacks independent review] → Require passing automated checks now and revisit required approvals when a second trusted maintainer is available.
+- [Package overrides can conceal upstream dependency lag] → Keep the override narrowly scoped, remove it once the parent package resolves a patched version naturally, and verify the dependency tree in CI/local validation.
+- [Documentation may drift from GitHub settings] → Treat branch-rule configuration as a task with post-change API verification and record the expected settings in the triage document.
+
+## Migration Plan
+
+1. Add version-controlled policy and triage documentation, then update workflow and container configuration.
+2. Regenerate the lockfile and run the affected documentation validation commands and dependency audit.
+3. Configure the `main` branch ruleset in GitHub and verify its effective settings through the GitHub API/UI.
+4. Allow Scorecard and CodeQL to run on the resulting `main` commit; verify actionable findings have cleared or have a documented intentional exception.
+
+Rollback consists of reverting the configuration commit for workflow/container/dependency regressions, or temporarily relaxing only the affected branch-rule requirement through GitHub administration. The security policy and triage record should remain published during rollback.
+
+## Open Questions
+
+- Which existing workflow check names must be selected in the GitHub ruleset after their next successful runs?
+- What private reporting channel (GitHub private vulnerability reporting, a monitored email address, or both) will the maintainer commit to in `SECURITY.md`?
+- Does the current npm release graph allow `basic-ftp` 5.3.1 through a normal lockfile refresh, or is a temporary root override required?

--- a/openspec/changes/harden-repository-supply-chain/proposal.md
+++ b/openspec/changes/harden-repository-supply-chain/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+The public repository has fourteen OpenSSF Scorecard findings. Several identify concrete, low-cost supply-chain and governance gaps: mutable build inputs, overly broad workflow permission placement, no security disclosure policy, an unprotected default branch, and a known-vulnerable transitive development dependency. Addressing the actionable findings now improves reproducibility and reduces repository-administration risk without imposing unsuitable controls on a sole-maintainer project.
+
+## What Changes
+
+- Protect `main` against destructive changes and require the existing validation workflows before merging, with rules enforced for administrators.
+- Narrow CodeQL's `security-events: write` permission to its analysis job.
+- Add a repository security policy with a private vulnerability-reporting path and response expectations.
+- Make development-container and CI-installed tooling deterministic by pinning the base image and package/module versions; replace implicit `npx` invocations with lockfile-backed project scripts.
+- Resolve the vulnerable transitive `basic-ftp` development dependency to a version patched for both known denial-of-service advisories.
+- Document intentional Scorecard exceptions for peer review, fuzzing, certification badge, and historical SAST coverage.
+
+## Capabilities
+
+### New Capabilities
+- `repository-security-governance`: Defines protected-branch controls, vulnerability reporting, and documented exceptions appropriate to this repository's maintainer model.
+- `reproducible-development-tooling`: Defines deterministic source and version selection for development-container and documentation-validation tooling.
+- `development-dependency-security`: Defines remediation requirements for known vulnerable development dependencies.
+
+### Modified Capabilities
+- None.
+
+## Impact
+
+- Affects GitHub branch rules and `.github/workflows/codeql.yml`, `.github/workflows/docs-validation.yml`, and associated repository documentation.
+- Affects `.devcontainer/Dockerfile`, `package.json`, and `package-lock.json`.
+- Adds a security policy and a documented Scorecard-triage record.
+- No public site API, content format, or runtime visitor behavior changes.

--- a/openspec/changes/harden-repository-supply-chain/specs/development-dependency-security/spec.md
+++ b/openspec/changes/harden-repository-supply-chain/specs/development-dependency-security/spec.md
@@ -1,0 +1,19 @@
+## ADDED Requirements
+
+### Requirement: Patched basic-ftp development resolution
+The committed Node dependency resolution SHALL use `basic-ftp` version 5.3.1 or later whenever the Mermaid CLI development dependency graph is installed.
+
+#### Scenario: Development dependencies are installed
+- **WHEN** a contributor or CI runs the lockfile-based Node installation
+- **THEN** the resolved `basic-ftp` version is 5.3.1 or later
+
+### Requirement: Advisory remediation verification
+The dependency remediation SHALL be verified against GHSA-rp42-5vxx-qpwr and GHSA-rpmf-866q-6p89, and the project SHALL retain its existing Mermaid CLI functionality.
+
+#### Scenario: Dependency security validation runs
+- **WHEN** the updated lockfile is audited and its dependency tree is inspected
+- **THEN** neither advisory is satisfied by a `basic-ftp` version at or below 5.3.0
+
+#### Scenario: Mermaid tooling is invoked
+- **WHEN** the existing Mermaid validation or rendering tooling runs after the dependency update
+- **THEN** it completes using the updated dependency resolution

--- a/openspec/changes/harden-repository-supply-chain/specs/repository-security-governance/spec.md
+++ b/openspec/changes/harden-repository-supply-chain/specs/repository-security-governance/spec.md
@@ -1,0 +1,33 @@
+## ADDED Requirements
+
+### Requirement: Default branch integrity
+The repository SHALL protect `main` from deletion and force pushes, SHALL require a pull request and successful designated validation checks before merge, and SHALL enforce those controls for administrators.
+
+#### Scenario: Normal change reaches main
+- **WHEN** a pull request targets `main`
+- **THEN** it cannot merge until all designated required checks have succeeded
+
+#### Scenario: Destructive branch operation is attempted
+- **WHEN** any actor attempts to delete or force-push `main`
+- **THEN** GitHub rejects the operation
+
+### Requirement: Sole-maintainer review exception
+The repository SHALL NOT require an approving peer review while it has only one trusted maintainer with merge access, and SHALL document that exception and its reconsideration trigger.
+
+#### Scenario: Maintainer model changes
+- **WHEN** a second trusted maintainer receives merge access
+- **THEN** the repository governance documentation identifies required peer-review enforcement as requiring review
+
+### Requirement: Vulnerability reporting policy
+The repository SHALL publish a `SECURITY.md` that defines supported scope, a private reporting channel, expected acknowledgement expectations, and a prohibition on public disclosure before coordination.
+
+#### Scenario: Researcher reports a vulnerability
+- **WHEN** a researcher opens the repository security policy
+- **THEN** they can identify a private reporting route and the expected response process
+
+### Requirement: Intentional Scorecard exception record
+The repository SHALL version-control the rationale and reconsideration conditions for intentionally unaddressed Scorecard findings covering fuzzing, the OpenSSF Best Practices badge, historical-commit SAST coverage, and the sole-maintainer review exception.
+
+#### Scenario: Contributor reviews an open Scorecard finding
+- **WHEN** a contributor reads the triage record
+- **THEN** they can distinguish intentional exceptions from findings that require remediation

--- a/openspec/changes/harden-repository-supply-chain/specs/reproducible-development-tooling/spec.md
+++ b/openspec/changes/harden-repository-supply-chain/specs/reproducible-development-tooling/spec.md
@@ -1,0 +1,40 @@
+## ADDED Requirements
+
+### Requirement: Immutable development-container base image
+The development-container Dockerfile SHALL select its base image by immutable digest while retaining a readable version tag.
+
+#### Scenario: Base tag is republished upstream
+- **WHEN** the upstream base-image tag changes after this change is merged
+- **THEN** a build using the committed Dockerfile resolves the originally reviewed image digest
+
+### Requirement: Pinned development-container tool installs
+The development-container Dockerfile SHALL install npm packages and Go modules using explicit versions and SHALL NOT use `latest` for executable tooling.
+
+#### Scenario: Devcontainer rebuild occurs later
+- **WHEN** a contributor rebuilds the development container from the committed Dockerfile
+- **THEN** the installed npm and Go tools match the versions declared in the Dockerfile
+
+### Requirement: Lockfile-backed documentation validation commands
+The documentation-validation workflow SHALL install Node dependencies from the committed lockfile and SHALL invoke project-defined npm scripts for Node-based validation commands.
+
+#### Scenario: Documentation validation runs in CI
+- **WHEN** the documentation-validation workflow executes after `npm ci`
+- **THEN** Node validation commands use the versions resolved by the committed lockfile without fetching an undeclared command package
+
+### Requirement: Pinned CI Go tool installation
+The documentation-validation workflow SHALL install htmltest at an explicit Go module version and SHALL NOT request its `latest` version.
+
+#### Scenario: CI runs link validation
+- **WHEN** the documentation-validation workflow installs htmltest
+- **THEN** it installs the explicit declared version before running link validation
+
+### Requirement: Least-privilege CodeQL upload permission
+The CodeQL workflow SHALL grant `security-events: write` only to the job that uploads CodeQL analysis results.
+
+#### Scenario: CodeQL analysis publishes results
+- **WHEN** the CodeQL analysis job completes successfully
+- **THEN** it can upload security results to GitHub code scanning
+
+#### Scenario: Other workflow jobs execute
+- **WHEN** a non-CodeQL job runs
+- **THEN** it does not receive CodeQL's security-events write permission

--- a/openspec/changes/harden-repository-supply-chain/tasks.md
+++ b/openspec/changes/harden-repository-supply-chain/tasks.md
@@ -21,6 +21,6 @@
 ## 4. Validation and alert follow-up
 
 - [x] 4.1 Run the affected documentation validation, Mermaid validation, dependency-tree inspection, and dependency audit commands.
-- [ ] 4.2 Confirm CodeQL can upload results with the narrowed job permission.
+- [x] 4.2 Confirm CodeQL can upload results with the narrowed job permission.
 - [ ] 4.3 Confirm the next Scorecard run clears the actionable workflow/container/dependency findings or record any scanner limitation.
 - [x] 4.4 Dismiss the intentional Scorecard findings in GitHub with the version-controlled triage rationale.

--- a/openspec/changes/harden-repository-supply-chain/tasks.md
+++ b/openspec/changes/harden-repository-supply-chain/tasks.md
@@ -1,0 +1,26 @@
+## 1. Repository governance
+
+- [x] 1.1 Enable or identify the GitHub private vulnerability-reporting channel and add `SECURITY.md` with supported scope, reporting process, acknowledgement target, and coordinated-disclosure guidance.
+- [x] 1.2 Add a version-controlled Scorecard triage record documenting intentional exceptions for sole-maintainer reviews, fuzzing, the OpenSSF badge, and historical SAST coverage, including reconsideration triggers.
+- [x] 1.3 Configure a `main` branch ruleset that blocks deletion and force pushes, applies to administrators, requires pull requests, and requires the existing successful validation checks without requiring a peer approval.
+- [x] 1.4 Verify the effective branch ruleset through the GitHub API or repository settings and record the selected required check names.
+
+## 2. Workflow least privilege and reproducibility
+
+- [x] 2.1 Move `security-events: write` from CodeQL workflow scope to the CodeQL analysis job and preserve successful SARIF publication.
+- [x] 2.2 Pin the devcontainer base image by digest while retaining its readable tag.
+- [x] 2.3 Replace devcontainer `latest` npm and Go tool installs with explicit reviewed versions.
+- [x] 2.4 Add or use project npm scripts for Markdown linting and spellchecking, and update documentation validation to invoke those scripts after `npm ci`.
+- [x] 2.5 Pin the htmltest installation in documentation validation to an explicit Go module version.
+
+## 3. Dependency remediation
+
+- [x] 3.1 Update the Node dependency resolution so `basic-ftp` is at least 5.3.1, using a narrow root override only if a normal compatible refresh cannot select the patched release.
+- [x] 3.2 Regenerate and inspect `package-lock.json` to verify the patched `basic-ftp` resolution and preserve Mermaid CLI compatibility.
+
+## 4. Validation and alert follow-up
+
+- [x] 4.1 Run the affected documentation validation, Mermaid validation, dependency-tree inspection, and dependency audit commands.
+- [ ] 4.2 Confirm CodeQL can upload results with the narrowed job permission.
+- [ ] 4.3 Confirm the next Scorecard run clears the actionable workflow/container/dependency findings or record any scanner limitation.
+- [x] 4.4 Dismiss the intentional Scorecard findings in GitHub with the version-controlled triage rationale.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1890,9 +1890,9 @@
       "license": "MIT"
     },
     "node_modules/basic-ftp": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.2.tgz",
-      "integrity": "sha512-1tDrzKsdCg70WGvbFss/ulVAxupNauGnOlgpyjKzeQxzyllBLS0CGLV7tjIXTK3ZQA9/FBEm9qyFFN1bciA6pw==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.1.tgz",
+      "integrity": "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==",
       "dev": true,
       "license": "MIT",
       "peer": true,

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "markdownlint-cli": "^0.49.1"
   },
   "scripts": {
-    "lint:md": "markdownlint-cli \"content/**/*.md\" \".github/**/*.md\"",
+    "lint:md": "markdownlint \"content/**/*.md\" \".github/**/*.md\"",
     "lint:mermaid": "python3 scripts/lint-mermaid.py",
     "spell": "cspell \"content/**/*.md\""
   }


### PR DESCRIPTION
## Summary
- protect repository governance and document security reporting
- pin development and CI tool inputs
- remediate the vulnerable `basic-ftp` development resolution

## Validation
- `npm ci`
- `npm run lint:md`
- `npm run spell`
- `./.githooks/validate-frontmatter.sh`
- `hugo build -d public`
- `htmltest -c .htmltest.yml -s public`
- `npm run lint:mermaid`
- `npm ls basic-ftp --all`
- `npm audit --omit=optional --audit-level=high`
