### PR TITLE
chore(openspec): archive supply-chain change

### DIFF
--- a/docs/scorecard-triage.md
+++ b/docs/scorecard-triage.md
@@ -18,6 +18,10 @@ This record distinguishes Scorecard findings that require remediation from inten
 | OpenSSF Best Practices badge | Earning and maintaining the external badge is not a project goal. Concrete security controls are tracked and improved independently of badge status. | Reassess if users, contributors, or the project governance model require external certification. |
 | SAST coverage of historical commits | CodeQL analyzes the current tree on pushes and pull requests. Retrospective scanning of every historical commit would not improve protection for the deployed static site proportionately. | Reassess after a security incident, a significant codebase expansion, or a governance requirement for historical analysis. |
 
+## Scanner limitations
+
+Scorecard alerts **#4** and **#5** both identify `npmCommand not pinned by hash` at the same devcontainer instruction. The Dockerfile installs `npm@12.0.1` and `markdownlint-cli@0.49.1` by explicit reviewed versions, which satisfies the repository reproducibility requirement. Scorecard's Dockerfile heuristic treats npm package versions as mutable unless the command itself includes a hash, even though npm package installation does not support a practical package-content hash form in this command. The alerts are dismissed as duplicate scanner limitations and must be reconsidered if Scorecard adds support for version-pinned npm installs or the devcontainer installation method changes.
+
 ## Branch ruleset verification
 
 The effective GitHub ruleset for `main` is verified after configuration through the GitHub API. Required status checks: `Dependency review`, `Analyze (python)`, and `Validate documentation (Hugo, linters, spellcheck, linkcheck)`. No approving peer review is required while the sole-maintainer exception applies.

--- a/openspec/changes/harden-repository-supply-chain/tasks.md
+++ b/openspec/changes/harden-repository-supply-chain/tasks.md
@@ -22,5 +22,5 @@
 
 - [x] 4.1 Run the affected documentation validation, Mermaid validation, dependency-tree inspection, and dependency audit commands.
 - [x] 4.2 Confirm CodeQL can upload results with the narrowed job permission.
-- [ ] 4.3 Confirm the next Scorecard run clears the actionable workflow/container/dependency findings or record any scanner limitation.
+- [x] 4.3 Confirm the next Scorecard run clears the actionable workflow/container/dependency findings or record any scanner limitation.
 - [x] 4.4 Dismiss the intentional Scorecard findings in GitHub with the version-controlled triage rationale.


### PR DESCRIPTION
## Summary\n- sync the three completed capability specs to \n- archive \n- retain the documented Scorecard scanner limitation\n\nAll OpenSpec artifacts and tasks are complete.