### PR TITLE
fix(deps): update brace-expansion

### DIFF
--- a/openspec/changes/archive/2026-07-21-fix-brace-expansion-alert/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-21-fix-brace-expansion-alert/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-21

--- a/openspec/changes/archive/2026-07-21-fix-brace-expansion-alert/design.md
+++ b/openspec/changes/archive/2026-07-21-fix-brace-expansion-alert/design.md
@@ -1,0 +1,43 @@
+## Context
+
+Dependabot alert #44 identifies vulnerable `brace-expansion@5.0.6` in the committed npm development dependency graph. The package is reached through `markdownlint-cli@0.49.1` → `minimatch@10.2.5`, and is installed by the documentation-validation workflow through `npm ci`. `minimatch` already declares `brace-expansion@^5.0.5`, which accepts the patched 5.0.7 release. The repository also installs `markdownlint-cli@0.49.1` globally in the development container, but that installation is independent of the committed lockfile.
+
+The change must remediate the recorded lockfile resolution while preserving reproducible, lockfile-backed CI behavior. The requester also requires a pull request, successful required checks, and a final completion notification.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Resolve `brace-expansion` to 5.0.7 or later in the committed npm lockfile.
+- Preserve the existing direct development dependencies and Markdown lint command.
+- Verify the resolved dependency tree and affected lint command before submitting a pull request.
+- Create a pull request, wait for required checks to succeed, then notify the requester of completion.
+
+**Non-Goals:**
+- Upgrade `markdownlint-cli`, `minimatch`, or unrelated dependencies.
+- Change production site behavior or add runtime input handling.
+- Treat the devcontainer's global npm installation as lockfile-controlled.
+- Merge the pull request unless separately requested.
+
+## Decisions
+
+### Refresh only the compatible transitive lockfile resolution
+Use npm's lockfile update path to select `brace-expansion@5.0.7` under the existing `^5.0.5` constraint from `minimatch`. This produces the smallest remediation and retains the existing direct dependency contract.
+
+**Alternative considered:** Add a root-level `overrides` entry. This would force the version but changes `package.json` and is unnecessary because the existing transitive semver range already accepts the patched release.
+
+### Validate the dependency graph and affected tooling
+Confirm the installed dependency tree resolves `brace-expansion` to a patched version, then run the repository's Markdown lint npm script. This directly checks the remediation and the only consumer path in this repository.
+
+**Alternative considered:** Rely solely on Dependabot's eventual closure. That does not prove the lockfile update preserves the lint command before opening a pull request.
+
+### Use a PR as the integration gate
+Commit the minimal lockfile change on a dedicated branch, create a pull request targeting `main`, and use GitHub's required checks as the final integration signal. Notify only after the PR reports a successful state; report a failing or incomplete check rather than claiming completion.
+
+**Alternative considered:** Merge immediately after local checks. This bypasses the repository's branch-protection and CI validation model, and exceeds the requester’s stated green-PR completion point.
+
+## Risks / Trade-offs
+
+- [The lockfile refresh updates unrelated packages] → Inspect the diff and constrain the change to the `brace-expansion` resolution; stop and reassess if unrelated upgrades appear.
+- [Local dependencies differ from a clean CI install] → Use a clean lockfile-based installation before validation where practical and rely on the pull request’s `npm ci` CI job as the final check.
+- [A PR check is queued, fails, or is not required] → Monitor check status to completion and notify the requester with the PR URL and actual status rather than assuming success.
+- [The development container’s global install remains a separate resolution] → Keep the scope explicit: alert #44 identifies the repository lockfile. Evaluate a devcontainer tool-version update separately if a scanner later reports it.

--- a/openspec/changes/archive/2026-07-21-fix-brace-expansion-alert/proposal.md
+++ b/openspec/changes/archive/2026-07-21-fix-brace-expansion-alert/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+Dependabot alert #44 reports a high-severity denial-of-service vulnerability (GHSA-3jxr-9vmj-r5cp / CVE-2026-13149) in the development-only `brace-expansion` resolution currently committed in `package-lock.json`. The current transitive version is 5.0.6; a compatible patched release is available and should be recorded in the lockfile so CI and contributors install the safe dependency tree.
+
+## What Changes
+
+- Refresh the committed npm lockfile so the transitive `brace-expansion` dependency resolves to patched version 5.0.7 or later without changing the direct development-tooling contract.
+- Validate the updated dependency tree against Dependabot alert #44 and run the affected documentation lint workflow locally.
+- Submit the remediation as a pull request, monitor its required validation, and notify the requester after the pull request is green.
+
+## Capabilities
+
+### New Capabilities
+
+- None.
+
+### Modified Capabilities
+
+- `development-dependency-security`: Extend development-dependency remediation requirements to cover the patched `brace-expansion` resolution and its advisory verification.
+
+## Impact
+
+- `package-lock.json` will change; `package.json` is not expected to change.
+- The `markdownlint-cli` → `minimatch` development-tooling path used by documentation linting will receive the patched transitive package.
+- Pull-request automation and the existing documentation-validation CI workflow will be used to verify the remediation.

--- a/openspec/changes/archive/2026-07-21-fix-brace-expansion-alert/specs/development-dependency-security/spec.md
+++ b/openspec/changes/archive/2026-07-21-fix-brace-expansion-alert/specs/development-dependency-security/spec.md
@@ -1,0 +1,19 @@
+## ADDED Requirements
+
+### Requirement: Patched brace-expansion development resolution
+The committed Node dependency resolution SHALL use `brace-expansion` version 5.0.7 or later whenever the Markdown lint development dependency graph is installed.
+
+#### Scenario: Development dependencies are installed
+- **WHEN** a contributor or CI runs the lockfile-based Node installation
+- **THEN** the resolved `brace-expansion` version is 5.0.7 or later
+
+### Requirement: Brace-expansion advisory remediation verification
+The dependency remediation SHALL be verified against GHSA-3jxr-9vmj-r5cp and CVE-2026-13149, and the project SHALL retain its existing Markdown lint functionality.
+
+#### Scenario: Dependency security validation runs
+- **WHEN** the updated lockfile is audited and its dependency tree is inspected
+- **THEN** the resolved `brace-expansion` version is not within any vulnerable range identified by GHSA-3jxr-9vmj-r5cp
+
+#### Scenario: Markdown lint tooling is invoked
+- **WHEN** the existing Markdown lint npm script runs after the dependency update
+- **THEN** it completes using the updated dependency resolution

--- a/openspec/changes/archive/2026-07-21-fix-brace-expansion-alert/tasks.md
+++ b/openspec/changes/archive/2026-07-21-fix-brace-expansion-alert/tasks.md
@@ -1,0 +1,15 @@
+## 1. Dependency remediation
+
+- [x] 1.1 Refresh the npm lockfile to resolve the transitive `brace-expansion` dependency to version 5.0.7 or later without changing direct development dependencies.
+- [x] 1.2 Inspect the lockfile diff and confirm it contains no unrelated dependency updates.
+
+## 2. Local verification
+
+- [x] 2.1 Perform a lockfile-based dependency installation and verify the resolved `brace-expansion` version is outside the vulnerable ranges in GHSA-3jxr-9vmj-r5cp.
+- [x] 2.2 Run the existing Markdown lint npm script successfully using the updated dependency resolution.
+
+## 3. Pull request completion
+
+- [x] 3.1 Commit the minimal remediation on a dedicated branch and create a pull request targeting `main` that references Dependabot alert #44.
+- [x] 3.2 Monitor the pull request until its required checks complete successfully; investigate and resolve remediation-related failures if they occur.
+- [x] 3.3 Notify the requester with the pull request URL and its green validation status.

--- a/openspec/specs/development-dependency-security/spec.md
+++ b/openspec/specs/development-dependency-security/spec.md
@@ -21,3 +21,21 @@ The dependency remediation SHALL be verified against GHSA-rp42-5vxx-qpwr and GHS
 - **WHEN** the existing Mermaid validation or rendering tooling runs after the dependency update
 - **THEN** it completes using the updated dependency resolution
 
+### Requirement: Patched brace-expansion development resolution
+The committed Node dependency resolution SHALL use `brace-expansion` version 5.0.7 or later whenever the Markdown lint development dependency graph is installed.
+
+#### Scenario: Development dependencies are installed
+- **WHEN** a contributor or CI runs the lockfile-based Node installation
+- **THEN** the resolved `brace-expansion` version is 5.0.7 or later
+
+### Requirement: Brace-expansion advisory remediation verification
+The dependency remediation SHALL be verified against GHSA-3jxr-9vmj-r5cp and CVE-2026-13149, and the project SHALL retain its existing Markdown lint functionality.
+
+#### Scenario: Dependency security validation runs
+- **WHEN** the updated lockfile is audited and its dependency tree is inspected
+- **THEN** the resolved `brace-expansion` version is not within any vulnerable range identified by GHSA-3jxr-9vmj-r5cp
+
+#### Scenario: Markdown lint tooling is invoked
+- **WHEN** the existing Markdown lint npm script runs after the dependency update
+- **THEN** it completes using the updated dependency resolution
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -1914,9 +1914,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
Resolves Dependabot alert #44 by updating the lockfile-only transitive `brace-expansion` resolution to 5.0.7.\n\nValidation:\n- `npm ci --ignore-scripts`\n- `npm ls brace-expansion --all`\n- `npm audit --json` (no brace-expansion finding)\n- `npm run lint:md`